### PR TITLE
freeze_heredoc deprecation

### DIFF
--- a/lib/creds/errors.rb
+++ b/lib/creds/errors.rb
@@ -6,7 +6,8 @@ class Creds
       Creds will return nil for any key.
       Run this to generate your credentials file:
         $ bin/rails credentials:edit
-      MSG.freeze
+      MSG
+        .freeze
   end
 
   # @api private
@@ -41,7 +42,8 @@ class Creds
   production:
     <<: *default
     aws_key: 'you can override defaults for individual environments'
-      MSG.freeze
+      MSG
+        .freeze
     # rubocop:enable Layout/TrailingWhitespace
 
     def initialize(env)
@@ -57,7 +59,8 @@ class Creds
 
         Either get or recover the file config/master.key
         or set the environment variable RAILS_MASTER_KEY
-      MSG.freeze
+      MSG
+        .freeze
 
     def initalize
       super(MESSAGE)

--- a/lib/creds/errors.rb
+++ b/lib/creds/errors.rb
@@ -6,8 +6,7 @@ class Creds
       Creds will return nil for any key.
       Run this to generate your credentials file:
         $ bin/rails credentials:edit
-      MSG
-        .strip_heredoc.freeze
+      MSG.freeze
   end
 
   # @api private
@@ -42,8 +41,7 @@ class Creds
   production:
     <<: *default
     aws_key: 'you can override defaults for individual environments'
-      MSG
-        .strip_heredoc.freeze
+      MSG.freeze
     # rubocop:enable Layout/TrailingWhitespace
 
     def initialize(env)
@@ -59,8 +57,7 @@ class Creds
 
         Either get or recover the file config/master.key
         or set the environment variable RAILS_MASTER_KEY
-      MSG
-        .strip_heredoc.freeze
+      MSG.freeze
 
     def initalize
       super(MESSAGE)


### PR DESCRIPTION
As detailed here : https://github.com/rails/rails/pull/32037

the following error occurs (rails 6.0.0.rc1 / ruby 2.6.1) :

```
...ruby-2.6.1/gems/rails-creds-0.2.2/lib/creds/errors.rb:10:in `<class:MissingCredentialsWarning>': undefined method `strip_heredoc' for #<String:0x00007ffc768d5188> (NoMethodError)
```

This PR might not be enough, in case it helps