### PR TITLE
Merge top-level creds into scoped

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,24 +1,30 @@
-# 0.2.3 (2019-08-19)
+# Unreleased
 
-Fixed:
+### Breaking changes
+
+- _(Possibly breaking)_ Scoped creds are now merged with top level creds ([#23](https://github.com/mikker/rails-creds/pull/23))
+
+## 0.2.3 (2019-08-19)
+
+### Fixed:
 
   - Require strip_heredoc extension before use
 
-# 0.2.1
+## 0.2.1
 
-Changed:
+## Changed:
 
   - Credentials are now memoized after successful read.
 
-# 0.2.0
+## 0.2.0
 
-Changed:
+### Changed:
 
   - Creds will now warn about missing credentials when the encrypted file isn't
     found. It will afterwards be a Null Object and return `nil` on every key.
   - When encrypted credentials are found but the master key file AND env
     variable is missing, Creds will return a special error with explanation.
 
-# 0.1.0
+## 0.1.0
 
 Initial version

--- a/README.md
+++ b/README.md
@@ -10,17 +10,9 @@ Given encrypted credentials looking like:
 
 ```yaml
 ---
-default: &default
-  super_secret: 'shared between environments'
-
-development:
-  <<: *default
-
-test:
-  <<: *default
+super_secret: 'shared between environments'
 
 production:
-  <<: *default
   super_secret: 'you can override defaults for individual environments'
 ```
 

--- a/lib/creds.rb
+++ b/lib/creds.rb
@@ -58,7 +58,10 @@ class Creds
   private
 
   def fetch_credentials_for_current_env
-    Rails.application.credentials.fetch(Rails.env.to_sym)
+    base = Rails.application.credentials.config
+    scoped = base.fetch(Rails.env.to_sym)
+    base.delete(Rails.env.to_sym)
+    base.merge(scoped)
   rescue KeyError
     raise MissingEnvError, Rails.env
   end
@@ -70,6 +73,7 @@ class Creds
   def master_key_present?
     return true if ENV["RAILS_MASTER_KEY"]
     return true if File.exist?(Rails.root.join("config", "master.key"))
+
     false
   end
 end

--- a/lib/creds/errors.rb
+++ b/lib/creds/errors.rb
@@ -32,14 +32,7 @@ class Creds
   Here's an example of how your credentials could look:
 
   ---
-  default: &default
-    aws_key: 'shared between environments'
-  
-  development:
-    <<: *default
-  
-  test:
-    <<: *default
+  aws_key: 'shared between environments'
   
   production:
     <<: *default

--- a/spec/creds_spec.rb
+++ b/spec/creds_spec.rb
@@ -34,6 +34,11 @@ RSpec.describe Creds do
     expect(Creds.super_secret).to eq("shh!")
   end
 
+  it "merges top-level credentials" do
+    write_config(super_secret: "shh!", test: {other_secret: "SHH!"})
+    expect(Creds.super_secret).to eq("shh!")
+  end
+
   it "raises MissingKeyError on missing keys" do
     write_config(test: {super_secret: "shh!"})
     expect { Creds.non_existing_key }.to raise_error(Creds::MissingKeyError)


### PR DESCRIPTION
Like,

```yaml
secret: abc123
development:
  other: xyz789
```

```ruby
Creds.to_h # => { secret: 'abc123', other: 'xyz789' }
```

Skipping the need to do `default: &default` extending.